### PR TITLE
Amended deprecated call to .get_chromecast_from_service()

### DIFF
--- a/mpd2chromecast.py
+++ b/mpd2chromecast.py
@@ -102,8 +102,7 @@ def get_chromecast(name):
                 1,
                 "Getting chromecast device object")
         # Get the device handle
-        # FIXME this call has issues
-        device = pychromecast.get_chromecast_from_service(
+        device = pychromecast.get_chromecast_from_cast_info(
                 gv_discovered_devices[name],
                 gv_zconf)
     except:


### PR DESCRIPTION
The newest Volumio image dated 2021-02-26 failed calling pychomecast.get_chromecast_from_service() (deprecated).

See [this code].

[this code]: https://github.com/home-assistant-libs/pychromecast/blob/d9a9f31b249c1d78a0df220ad6b149b274f995ee/pychromecast/__init__.py#L97-L100